### PR TITLE
Replaced Segoe MDL2 gliphs by SVG's

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,18 +17,29 @@
 
         <div id="window-controls">
           <div class="button" id="min-button">
-            <span>&#xE921;</span>
+            <svg width="11" height="1" viewBox="0 0 11 1">
+              <path d="m11 0v1h-11v-1z" stroke-width=".26208"/>
+            </svg>
           </div>
           <div class="button" id="max-button">
-            <span>&#xE922;</span>
+            <svg width="10" height="10" viewBox="0 0 10 10">
+              <path d="m10-1.6667e-6v10h-10v-10zm-1.001 1.001h-7.998v7.998h7.998z" stroke-width=".25" />
+            </svg>
           </div>
           <div class="button" id="restore-button">
-            <span>&#xE923;</span>
+            <svg width="11" height="11" viewBox="0 0 11 11">
+              <path
+                d="m11 8.7978h-2.2021v2.2022h-8.7979v-8.7978h2.2021v-2.2022h8.7979zm-3.2979-5.5h-6.6012v6.6011h6.6012zm2.1968-2.1968h-6.6012v1.1011h5.5v5.5h1.1011z"
+                stroke-width=".275" />
+            </svg>
           </div>
           <div class="button" id="close-button">
-            <span>&#xE8BB;</span>
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <path
+                d="m6.8496 6 5.1504 5.1504-0.84961 0.84961-5.1504-5.1504-5.1504 5.1504-0.84961-0.84961 5.1504-5.1504-5.1504-5.1504 0.84961-0.84961 5.1504 5.1504 5.1504-5.1504 0.84961 0.84961z"
+                stroke-width=".3" />
+            </svg>
           </div>
-
         </div>
       </div>
     </header>

--- a/src/style.css
+++ b/src/style.css
@@ -112,6 +112,7 @@ body {
 #window-controls .button {
   user-select: none;
   cursor: default;
+  fill: white;
 }
 
 #window-controls .button:hover {


### PR DESCRIPTION
As the license of Segoe MDL2 Assets font does not allow usage of this font outside of Windows, this Pull Request proposes a solution that is independent of Segoe MDL2 Assets font.
The Segie MDL2 Assets gliphs have been replaced by SVG's which look almost exactly the same as the Segoe MDL2 window button glyphs.