### PR TITLE
Add transition when hovering over window buttons

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -123,6 +123,7 @@ body {
 
 #window-controls .button:hover {
   background: rgba(255,255,255,0.1);
+  transition: background 0.25s;
 }
 
 #window-controls .button:active {


### PR DESCRIPTION
Some Windows applications (File Explorer, Edge, Chrome, Windows Terminal) have a simple transition when hovering over the window buttons. I added this same transition to the window buttons for this application.